### PR TITLE
Fix: Memory explosion caused by neg_sample = 1

### DIFF
--- a/warprec/data/entities/train_structures/session_structures.py
+++ b/warprec/data/entities/train_structures/session_structures.py
@@ -85,8 +85,6 @@ class SequentialDataset(Dataset):
                 neg_items.append(cand)
 
             neg_tensor = torch.tensor(neg_items, dtype=torch.long)
-            if self.neg_samples == 1:
-                neg_tensor = neg_tensor.squeeze(0)
             ret.append(neg_tensor)
 
         return tuple(ret)


### PR DESCRIPTION
Fixed a bug that happened when neg_samples for sequential models was set to 1