### PR TITLE
chore: Added n_startup_trials configuration for Bayesian search algor…

### DIFF
--- a/warprec/recommenders/trainer/search_algorithm_wrapper.py
+++ b/warprec/recommenders/trainer/search_algorithm_wrapper.py
@@ -11,9 +11,10 @@ Author: Avolio Marco
 Date: 03/03/2025
 """
 
-from typing import Any
+from typing import Any, Optional
 from abc import ABC, abstractmethod
 
+from optuna.samplers import TPESampler
 from ray.tune.search.hyperopt import HyperOptSearch
 from ray.tune.search.optuna import OptunaSearch
 from ray.tune.search.bohb import TuneBOHB
@@ -74,27 +75,61 @@ class HyperOptWrapper(HyperOptSearch, BaseSearchWrapper):
             either 'min' or 'max'.
         metric (str): The metric to optimize.
         seed (int): The seed to make the experiment reproducible.
+        n_startup_trials (Optional[int]): The number of random trials to run
+            before the Parzen estimators start guiding the search. When None,
+            the HyperOpt default is kept.
         **kwargs (Any): Keyword arguments.
     """
 
-    def __init__(self, mode: str, metric: str, seed: int, **kwargs: Any):
-        super().__init__(mode=mode, metric=metric, random_state_seed=seed)
+    def __init__(
+        self,
+        mode: str,
+        metric: str,
+        seed: int,
+        n_startup_trials: Optional[int] = None,
+        **kwargs: Any,
+    ):
+        warm_up = (
+            {} if n_startup_trials is None else {"n_initial_points": n_startup_trials}
+        )
+        super().__init__(mode=mode, metric=metric, random_state_seed=seed, **warm_up)
 
 
 @search_algorithm_registry.register(SearchAlgorithms.OPTUNA)
 class OptunaWrapper(OptunaSearch, BaseSearchWrapper):
-    """Wrapper for the HyperOpt algorithm in Ray Tune.
+    """Wrapper for the Optuna algorithm in Ray Tune.
 
     Args:
         mode (str): The mode to run the optimization. Must be
             either 'min' or 'max'.
         metric (str): The metric to optimize.
         seed (int): The seed to make the experiment reproducible.
+        n_startup_trials (Optional[int]): The number of random trials to run
+            before the Parzen estimators start guiding the search. When None,
+            the Optuna default is kept.
         **kwargs (Any): Keyword arguments.
     """
 
-    def __init__(self, mode: str, metric: str, seed: int, **kwargs: Any):
-        super().__init__(mode=mode, metric=metric, seed=seed)
+    def __init__(
+        self,
+        mode: str,
+        metric: str,
+        seed: int,
+        n_startup_trials: Optional[int] = None,
+        **kwargs: Any,
+    ):
+        if n_startup_trials is None:
+            super().__init__(mode=mode, metric=metric, seed=seed)
+            return
+
+        # OptunaSearch does not expose `n_startup_trials`: it has to be set on
+        # the sampler. The seed is passed to the sampler as well, because Optuna
+        # ignores `seed` whenever a custom sampler is provided.
+        super().__init__(
+            mode=mode,
+            metric=metric,
+            sampler=TPESampler(seed=seed, n_startup_trials=n_startup_trials),
+        )
 
 
 @search_algorithm_registry.register(SearchAlgorithms.BOHB)

--- a/warprec/recommenders/trainer/search_algorithm_wrapper.py
+++ b/warprec/recommenders/trainer/search_algorithm_wrapper.py
@@ -89,10 +89,16 @@ class HyperOptWrapper(HyperOptSearch, BaseSearchWrapper):
         n_startup_trials: Optional[int] = None,
         **kwargs: Any,
     ):
-        warm_up = (
-            {} if n_startup_trials is None else {"n_initial_points": n_startup_trials}
+        if n_startup_trials is None:
+            super().__init__(mode=mode, metric=metric, random_state_seed=seed)
+            return
+
+        super().__init__(
+            mode=mode,
+            metric=metric,
+            random_state_seed=seed,
+            n_initial_points=n_startup_trials,
         )
-        super().__init__(mode=mode, metric=metric, random_state_seed=seed, **warm_up)
 
 
 @search_algorithm_registry.register(SearchAlgorithms.OPTUNA)

--- a/warprec/utils/config/model_configuration.py
+++ b/warprec/utils/config/model_configuration.py
@@ -63,6 +63,10 @@ class Properties(BaseModel):
         max_t (Optional[int]): Max time unit given to each trial.
         grace_period (Optional[int]): Min time unit given to each trial.
         reduction_factor (Optional[float]): Halving rate of trials.
+        n_startup_trials (Optional[int]): Number of random trials the Bayesian
+            search algorithms ('hopt', 'optuna') run before their surrogate
+            model starts guiding the search. When None, the default of the
+            underlying library is kept. Ignored by the other strategies.
     """
 
     mode: Optional[str] = "max"
@@ -72,6 +76,7 @@ class Properties(BaseModel):
     max_t: Optional[int] = None
     grace_period: Optional[int] = None
     reduction_factor: Optional[float] = None
+    n_startup_trials: Optional[int] = None
 
     @field_validator("mode")
     @classmethod
@@ -94,6 +99,14 @@ class Properties(BaseModel):
                 "Desired_training_it should be either: median, mean, min or max."
             )
         return v.lower()
+
+    @field_validator("n_startup_trials")
+    @classmethod
+    def check_n_startup_trials(cls, v: Optional[int]):
+        """Validate n_startup_trials."""
+        if v is not None and v <= 0:
+            raise ValueError("Value for n_startup_trials must be >0.")
+        return v
 
 
 class LRSchedulerConfig(BaseModel):
@@ -314,6 +327,14 @@ class Optimization(BaseModel):
                     "Reduction_factor property is required for ASHA scheduling. "
                     "Change type of scheduling or provide the reduction_factor attribute."
                 )
+        if self.properties.n_startup_trials is not None and self.strategy not in (
+            SearchAlgorithms.HYPEROPT,
+            SearchAlgorithms.OPTUNA,
+        ):
+            logger.attention(
+                "You have passed the field n_startup_trials but only the "
+                "'hopt' and 'optuna' strategies make use of it."
+            )
 
         return self
 


### PR DESCRIPTION
HyperOpt exposes n_initial_points directly, while OptunaSearch only allows it through a custom sampler. When the field is set, the seed is moved into the TPESampler, since Optuna ignores `seed` whenever a sampler is provided. Leaving the field unset preserves the previous behaviour exactly.